### PR TITLE
Remove the alternative stream URL fields

### DIFF
--- a/src/manage/extra-services/apps/request-app-ctrl.js
+++ b/src/manage/extra-services/apps/request-app-ctrl.js
@@ -369,24 +369,12 @@ export default /*@ngInject*/ function (
 
     // Alternative stream URL
     {
-      key: "needsAlternativeStreamUrl",
-      type: "fullHorizontalCheckbox",
-      defaultValue: false,
-      templateOptions: {
-        label: "I need to use an alternative stream URL",
-        description: "Only check this if you must use an alternative stream URL. This is useful when you are using a stream licensing service that forces you to use their stream URL.",
-      },
-    },
-    {
-      key: "alternativeStreamUrl",
-      type: "horizontalInput",
-      templateOptions: {
-        label: "Alternative Stream URL",
-        type: "url",
-        placeholder: "http(s)://…",
-        required: true,
-      },
-      hideExpression: "!model.needsAlternativeStreamUrl",
+      template: `<div class="form-group">
+  <label class="control-label col-sm-3">Alternative Stream URL</label>
+  <div class="col-sm-9">
+  <p>Please open a ticket if you need to use an alternative stream URL for licensing or any other legal reason.</p>
+  </div>
+</div>`,
     },
 
     {

--- a/src/manage/extra-services/player/player.html
+++ b/src/manage/extra-services/player/player.html
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="form-group col-sm-12 no-margin-bottom">
+                    <div class="form-group col-sm-12">
                         <div class="checkbox">
                             <hr class="no-margin-top">
                             <label>
@@ -83,23 +83,6 @@
                             </label>
                             <p class="help-block">Check this if you want the stream to automatically play on load.</p>
                         </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="form-group col-sm-12">
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox" ng-model="needsAlternativeTuneInURL"> I need to use an alternative stream URL
-                            </label>
-                            <p class="help-block">Only check this if you must use an alternative stream URL. This is useful when you are using a stream licensing service that forces you to use their stream URL, or if you need to use port 80.</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="form-group" show-errors ng-show="needsAlternativeTuneInURL">
-                    <label for="alternative-stream-url" class="col-sm-3 control-label">Alternative Stream URL</label>
-                    <div class="col-sm-9">
-                        <input id="alternative-stream-url" class="form-control" type="url" name="alternative-stream-url" placeholder="http(s)://..." ng-model="settings.alternativeStreamUrl" ng-required="needsAlternativeTuneInURL">
-                        <br>
                     </div>
                 </div>
                 <div class="row">


### PR DESCRIPTION
This commit removes the alternative stream URL fields for app requests
and configuring Player, since we've had many users (mis)use that.

Fixes issue #4.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/5)
<!-- Reviewable:end -->
