### PR TITLE
Fix double alert on session timeout

### DIFF
--- a/src/login/auth-service.js
+++ b/src/login/auth-service.js
@@ -37,8 +37,7 @@ export default class AuthService {
         $http.post(ENV.apiEndpoint + "/control/keep-alive")
           .then(function (res) {
             Session.update(res.data.token);
-          }, function (response) {
-            $rootScope.$broadcast(AUTH_EVENTS.sessionTimeout, response);
+          }, function () {
             $interval.cancel(AuthService.keepAlivePromise);
             AuthService.keepAlivePromise = null;
           });


### PR DESCRIPTION
Turns out we were broadcasting the session timed out event twice, once
in the session keepalive code; another time when a request fails with
419.

This fixes issue #9.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/16)
<!-- Reviewable:end -->
