### PR TITLE
Apps: Block app request edits in some cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "font-awesome": "^4.5.0",
     "jquery": "^2.1.4",
     "lodash": "^3.10.1",
+    "moment": "^2.11.1",
     "ui-select": "^0.13.2"
   },
   "devDependencies": {

--- a/src/common/css-helpers/flex-left-right.css
+++ b/src/common/css-helpers/flex-left-right.css
@@ -1,0 +1,16 @@
+.flex-left-right {
+  display: flex;
+  justify-content: space-between;
+
+  .left {
+    flex: 1;
+    margin-right: auto;
+    text-align: left;
+  }
+  .right {
+    flex: 1;
+    margin-left: auto;
+    text-align: right;
+  }
+}
+

--- a/src/common/footer.css
+++ b/src/common/footer.css
@@ -42,20 +42,4 @@ body {
       margin-right: 0;
     }
   }
-
-  .footer-links {
-    display: flex;
-    justify-content: space-between;
-
-    .left {
-      flex: 1;
-      margin-right: auto;
-      text-align: left;
-    }
-    .right {
-      flex: 1;
-      margin-left: auto;
-      text-align: right;
-    }
-  }
 }

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,3 +1,4 @@
+import "./css-helpers/flex-left-right.css";
 import "./footer.css";
 
 import { angular, angularRoute } from "../vendor";

--- a/src/index.html
+++ b/src/index.html
@@ -89,7 +89,7 @@
     </div>
     <footer id="main-footer">
         <div class="container">
-            <div class="footer-links">
+            <div class="footer-links flex-left-right">
                 <span class="left">
                     <span class="copyright">© 2016  SHOUTca.st</span>
                     <a href="https://my.shoutca.st/submitticket.php?step=2&deptid=2">Help</a> &bull;

--- a/src/manage/extra-services/apps/view-app-request.html
+++ b/src/manage/extra-services/apps/view-app-request.html
@@ -9,16 +9,17 @@
 <div class="panel panel-default" ng-show="ctrl.app && ctrl.app._id">
 <div class="panel-body">
 
-<h4 class="pull-left"><a class="back-button" href="/manage/apps"><fa name="chevron-left"></fa></a> Mobile Apps <small><i class="fa" ng-class="{'fa-apple': ctrl.isiOSApp, 'fa-android': ctrl.isAndroidApp}"></i> {{ctrl.app._id}} ({{ctrl.app.username}})</small></h4>
-<div class="pull-right no-transition visible-md visible-lg" ng-hide="editableForm.$visible">
-    <button ng-show="!editableForm.$visible" class="btn btn-default broad-button" ng-click="editableForm.$show()"><i class="fa fa-edit"></i> Edit</button>
+<div class="flex-left-right">
+<h4 class="left"><a class="back-button" href="/manage/apps"><fa name="chevron-left"></fa></a> Mobile Apps <small><i class="fa" ng-class="{'fa-apple': ctrl.isiOSApp, 'fa-android': ctrl.isAndroidApp}"></i> {{ctrl.app._id}} ({{ctrl.app.username}})</small></h4>
+<div class="right no-transition visible-md visible-lg" ng-hide="editableForm.$visible">
+    <button ng-show="!editableForm.$visible" class="btn btn-default broad-button" ng-click="!ctrl.shouldBlockEditing(ctrl.app).blocked && editableForm.$show()" ng-class="{ disabled: ctrl.shouldBlockEditing(ctrl.app).blocked }" bs-tooltip data-title="{{ctrl.shouldBlockEditing(ctrl.app).blocked ? ctrl.shouldBlockEditing(ctrl.app).reason : ''}}" data-container="body"><i class="fa fa-edit"></i> Edit</button>
 </div>
-<div class="pull-right no-transition visible-md visible-lg" ng-show="editableForm.$visible">
+<div class="right no-transition visible-md visible-lg" ng-show="editableForm.$visible">
     <button type="submit" class="btn btn-primary broad-button" ng-disabled="editableForm.$waiting" form="info-form"><i class="fa fa-save"></i> Save</button>&nbsp;&nbsp;
     <button type="button" class="btn btn-default broad-button" ng-disabled="editableForm.$waiting" ng-click="editableForm.$cancel()">Cancel</button>
 </div>
+</div>
 
-<div class="clearfix"></div>
 <br>
 
 <form editable-form name="editableForm" id="info-form" onbeforesave="ctrl.beforeSave()" onaftersave="ctrl.save()" onshow="ctrl.onEdit()" oncancel="ctrl.onCancel()">
@@ -163,7 +164,7 @@
     </div>
 </div>
 <div class="no-transition hidden-md hidden-lg" ng-hide="editableForm.$visible">
-    <button ng-show="!editableForm.$visible" class="btn btn-default btn-block" ng-click="editableForm.$show()"><i class="fa fa-edit"></i> Edit</button>
+    <button ng-show="!editableForm.$visible" class="btn btn-default btn-block" ng-click="!ctrl.shouldBlockEditing(ctrl.app).blocked && editableForm.$show()" ng-class="{ disabled: ctrl.shouldBlockEditing(ctrl.app).blocked }" bs-tooltip data-title="{{ctrl.shouldBlockEditing(ctrl.app).blocked ? ctrl.shouldBlockEditing(ctrl.app).reason : ''}}" data-container="body"><i class="fa fa-edit"></i> Edit</button>
 </div>
 
 <br>


### PR DESCRIPTION
This commit adds client-side code to block app request edits in the
following cases:

- When an app request is Pending (or Update Pending), and the submitted
  or last updated date is more than 5 minutes ago. This is to prevent
  users from updating their requests simply because they think that'll
  get their requests processed faster.

- When the request status is In Progress. It's obviously a bad idea to
  update an app request when it is in the middle of a submission or
  of a build for iOS apps.

- When the app request is for an iOS app, and the status is Submitted
  or Update Submitted. We cannot update apps when they've been
  submitted for review to Apple, so let's just deny those.

For the moment, the check merely disables the button. It doesn't really
prevent someone with sufficient knowledge from submitting an update
(unless we add a server-side check, but that's probably overkill,
considering that most (all?) of our users do not have the required
skills to even know it's possible).

Fixes issue #3.

PS: Parts of the .footer-links CSS is moved into a new shared class,
.flex-left-right to reuse more code or (more precisely) styles.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/17)
<!-- Reviewable:end -->
