### PR TITLE
Fix the GeoLock icon

### DIFF
--- a/src/manage/cast/geolock/index.js
+++ b/src/manage/cast/geolock/index.js
@@ -1,3 +1,5 @@
+import "./geolock-icon.css";
+
 import { angular } from "../../../vendor";
 
 import GeoLockCtrl from "./geolock-ctrl.js";


### PR DESCRIPTION
This fixes a regression introduced by c9b5399, which caused the GeoLock
icon CSS not to be included (so the GeoLock icon was displayed and
positioned incorrectly as two separate Font Awesome icons).

Fixes issue #19.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/20)
<!-- Reviewable:end -->
