### PR TITLE
Apps: Show the rejection reason (if any)

### DIFF
--- a/src/common/styles/02-helpers.css
+++ b/src/common/styles/02-helpers.css
@@ -75,6 +75,9 @@
     margin-left: auto;
     text-align: right;
   }
+  .flex-auto {
+    flex: 0 auto;
+  }
 }
 
 /* spacing */

--- a/src/manage/extra-services/apps/app-request-ctrl.js
+++ b/src/manage/extra-services/apps/app-request-ctrl.js
@@ -65,6 +65,10 @@ export default /*@ngInject*/ function (
     return EDIT_BLOCKED_REASONS.DEFAULT;
   };
 
+  ctrl.hasBeenRejected = () => {
+    return ctrl.app.reviews.some(review => review.actionTaken === "reject");
+  };
+
   ctrl.addTab = function (type, value) {
     if (ctrl.app.tabs.length === 3) {
       $alert({

--- a/src/manage/extra-services/apps/app-status-filter.js
+++ b/src/manage/extra-services/apps/app-status-filter.js
@@ -41,7 +41,7 @@ export /*@ngInject*/ function appStatusExplanation() {
         return "Your app update has been approved by Apple and will be available within 24 hours.";
       case "iOS.onHold":
       case "android.onHold":
-        return "Your app request has some issues. Please contact support to resolve this situation.";
+        return "Your app request was rejected by our team.";
       case "android.rejectedByGoogle":
         return "Your app request has some issues and was rejected by Google. Please contact support to resolve this situation.";
       case "iOS.rejectedByGoogle":

--- a/src/manage/extra-services/apps/view-app-request.html
+++ b/src/manage/extra-services/apps/view-app-request.html
@@ -10,11 +10,11 @@
 <div class="panel-body">
 
 <div class="flex-left-right">
-<h4 class="left"><a class="back-link" href="/manage/apps"><fa name="chevron-left"></fa></a> Mobile Apps <small><i class="fa" ng-class="{'fa-apple': ctrl.isiOSApp, 'fa-android': ctrl.isAndroidApp}"></i> {{ctrl.app._id}} ({{ctrl.app.username}})</small></h4>
-<div class="right no-transition visible-md visible-lg" ng-hide="editableForm.$visible">
+<h4 class="left flex-auto"><a class="back-link" href="/manage/apps"><fa name="chevron-left"></fa></a> Mobile Apps <small><i class="fa" ng-class="{'fa-apple': ctrl.isiOSApp, 'fa-android': ctrl.isAndroidApp}"></i> {{ctrl.app._id}} ({{ctrl.app.username}})</small></h4>
+<div class="right flex-auto no-transition visible-md visible-lg" ng-hide="editableForm.$visible">
     <button ng-show="!editableForm.$visible" class="btn btn-default broad-button" ng-click="!ctrl.shouldBlockEditing(ctrl.app).blocked && editableForm.$show()" ng-class="{ disabled: ctrl.shouldBlockEditing(ctrl.app).blocked }" bs-tooltip data-title="{{ctrl.shouldBlockEditing(ctrl.app).blocked ? ctrl.shouldBlockEditing(ctrl.app).reason : ''}}" data-container="body"><i class="fa fa-edit"></i> Edit</button>
 </div>
-<div class="right no-transition visible-md visible-lg" ng-show="editableForm.$visible">
+<div class="right flex-auto no-transition visible-md visible-lg" ng-show="editableForm.$visible">
     <button type="submit" class="btn btn-primary broad-button" ng-disabled="editableForm.$waiting" form="info-form"><i class="fa fa-save"></i> Save</button>&nbsp;&nbsp;
     <button type="button" class="btn btn-default broad-button" ng-disabled="editableForm.$waiting" ng-click="editableForm.$cancel()">Cancel</button>
 </div>

--- a/src/manage/extra-services/apps/view-app-request.html
+++ b/src/manage/extra-services/apps/view-app-request.html
@@ -6,6 +6,14 @@
     </div>
 </div>
 
+<div class="alert alert-warning" ng-show="ctrl.app && ctrl.hasBeenRejected()">
+<p><fa name="warning"></fa> <b>This request was rejected for the following reason:</b></p>
+<p><i>{{ctrl.app.reviews[0].reason}}</i></p>
+<p>Tip: Do not update your request until you have completely fixed the issue.
+Otherwise, we will simply reject it again, which is a waste of time for both you and us.
+If you think this is a mistake, please <a href="https://my.shoutca.st/submitticket.php?step=2&deptid=2">open a ticket</a>.</p>
+</div>
+
 <div class="panel panel-default" ng-show="ctrl.app && ctrl.app._id">
 <div class="panel-body">
 


### PR DESCRIPTION
This makes Control show the last rejection reason (if the request was
rejected, of course), so the client knows why their app request was
rejected without having to check their emails.

Fixes issue #2.

Some screenshots:

![image](https://cloud.githubusercontent.com/assets/4209061/13202689/94b19322-d8a3-11e5-9ff4-996323992d63.png)

![details](https://cloud.githubusercontent.com/assets/4209061/13202691/9e658022-d8a3-11e5-9de4-57322a4f19ae.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/21)
<!-- Reviewable:end -->
