### PR TITLE
Fix unclosable, empty alert when session times out

### DIFF
--- a/src/common/auth/auth-event-handlers.js
+++ b/src/common/auth/auth-event-handlers.js
@@ -10,8 +10,6 @@ export default /*@ngInject*/ function ($rootScope, $location, $window, $alert, $
     });
   }
 
-  var alert;
-
   $rootScope.$on(AUTH_EVENTS.loginSuccess, function () {
     ServicesService.invalidateCache();
     return initServices().then(function onInitSuccess() {
@@ -65,27 +63,31 @@ export default /*@ngInject*/ function ($rootScope, $location, $window, $alert, $
     });
   });
 
+  let alertForBadRequest;
   $rootScope.$on(AUTH_EVENTS.badRequest, function onBadRequest() {
-    if (alert) {
-      alert.destroy();
+    if (alertForBadRequest) {
+      return;
     }
-    alert = $alert({
+    alertForBadRequest = $alert({
       content: "Something went wrong. Please try again. If the problem persists, reload the page and contact us.",
       type: "danger",
       duration: 10,
     });
+    setTimeout(() => alertForBadRequest = null, 5000); // rate-limit these alerts
   });
 
+  let alertForSessionTimeout;
   $rootScope.$on(AUTH_EVENTS.sessionTimeout, function onSessionTimeout() {
     Session.destroy();
     $location.path("/log-in");
-    if (alert) {
-      alert.destroy();
+    if (alertForSessionTimeout) {
+      return;
     }
-    alert = $alert({
+    alertForSessionTimeout = $alert({
       content: "Your session has expired, so you have been logged out.",
       type: "warning",
     });
+    setTimeout(() => alertForSessionTimeout = null, 5000); // rate-limit these alerts
   });
 
   $rootScope.$on(AUTH_EVENTS.notAuthenticated, function onNotAuthenticatedEvent() {


### PR DESCRIPTION
Looks like alert.destroy() does not work as expected at all. So instead
we are now skipping destroying and showing another alert altogether if
an alert was already shown in the last 5 seconds. This does not
completely fix the issue (which was that multiple session timeout
alerts shouldn't be shown at the same time) but it reduces it a lot.

Fixes issue #9.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/22)
<!-- Reviewable:end -->
