### PR TITLE
Apps: Add a honeycheckbox for clients who don't read

### DIFF
--- a/src/manage/extra-services/apps/request-app-ctrl.js
+++ b/src/manage/extra-services/apps/request-app-ctrl.js
@@ -82,6 +82,14 @@ export default /*@ngInject*/ function (
           },
         },
         {
+          key: "rejectMeImmediately",
+          type: "checkbox",
+          templateOptions: {
+            required: false,
+            label: "I want my request to be rejected immediately",
+          },
+        },
+        {
           type: "checkbox",
           templateOptions: {
             required: true,
@@ -425,6 +433,10 @@ export default /*@ngInject*/ function (
     request.username = $rootScope.service.username;
     if (!request.needsAlternativeStreamUrl) {
       request.alternativeStreamUrl = undefined;
+    }
+
+    if ($scope.confirmFormModel.rejectMeImmediately) {
+      request.rejectMeImmediately = true;
     }
 
     let promises = [];

--- a/src/manage/extra-services/apps/request-app.html
+++ b/src/manage/extra-services/apps/request-app.html
@@ -70,7 +70,7 @@
                     </div>
                 </div>
                 <br>
-                <formly-form fields="confirmFormFields" form="confirmForm">
+                <formly-form model="confirmFormModel" fields="confirmFormFields" form="confirmForm">
                 </formly-form>
                 </fieldset>
                 <div class="row">


### PR DESCRIPTION
This adds a honeypot checkbox ("honeycheckbox") which will instantly
and automatically reject requests if the user ticks it and submits the
form mindlessly, without reading what's written.

Sorry if this sounds evil, but it takes a lot of time to review app requests and about 75% of app requests end up rejected.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/23)
<!-- Reviewable:end -->
