### PR TITLE
Apps: Don't show alt stream URL field if it was not used

### DIFF
--- a/src/manage/extra-services/apps/view-app-request.html
+++ b/src/manage/extra-services/apps/view-app-request.html
@@ -51,7 +51,7 @@ If you think this is a mistake, please <a href="https://my.shoutca.st/submittick
                     <a ng-show="!editableForm.$visible" href="{{ctrl.app.streamUrl}}">{{ctrl.app.streamUrl}}</a>
                     <span ng-hide="!editableForm.$visible"><i>The stream URL will be filled in when you save the app.</i></span>
                 </dd>
-                <div ng-hide="!ctrl.app.alternativeStreamUrl && !editableForm.$visible">
+                <div ng-hide="!ctrl.app.alternativeStreamUrl">
                     <dt>Alternative Stream URL</dt>
                     <dd><span editable-url="ctrl.app.alternativeStreamUrl" e-placeholder="Override the stream URL (optional)"><a href="{{ctrl.app.alternativeStreamUrl}}">{{ctrl.app.alternativeStreamUrl}}</a></span></dd>
                 </div>


### PR DESCRIPTION
This prevents users from _helpfully_ filling in the alternative stream
URL field right after an app submission in cases where it is not needed
at all and only makes app updates more complicated.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/25)
<!-- Reviewable:end -->
