### PR TITLE
Apps: hasBeenRejected: Only consider the latest review

### DIFF
--- a/src/manage/extra-services/apps/app-request-ctrl.js
+++ b/src/manage/extra-services/apps/app-request-ctrl.js
@@ -66,7 +66,7 @@ export default /*@ngInject*/ function (
   };
 
   ctrl.hasBeenRejected = () => {
-    return ctrl.app.reviews.some(review => review.actionTaken === "reject");
+    return (ctrl.app.reviews[0] || {}).actionTaken === "reject";
   };
 
   ctrl.addTab = function (type, value) {


### PR DESCRIPTION
This avoids the "app request rejected" notice from appearing and
displaying an incomplete message (empty reason) even though the latest
revision of the app wasn't actually rejected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/26)
<!-- Reviewable:end -->
