### PR TITLE
Apps: Add a maxlength of 4000 for the description

### DIFF
--- a/src/manage/extra-services/apps/request-app-ctrl.js
+++ b/src/manage/extra-services/apps/request-app-ctrl.js
@@ -230,7 +230,8 @@ export default /*@ngInject*/ function (
         type: "horizontalTextarea",
         label: "App Description",
         required: true,
-        placeholder: "A description for your app, which shouldn't be too short and should have a minimum of 2 sentences.",
+        maxlength: 4000,
+        placeholder: "A description for your app, which shouldn't be too short and should have a minimum of 2 sentences. (Must be shorter than 4000 characters.)",
         description: "Describe your station. Why should someone download the app and listen to it? Avoid excessive keywords and pay attention to the grammar, as your app could get rejected otherwise. Also, do not write in ALL CAPS.",
         rows: 4,
         addonLeft: {


### PR DESCRIPTION
Apple apparently limits the description to 4000 characters, which is
already a lot but some users still managed to submit a description that
was longer than that. Hence this commit to add a maxlength validation.

Fixes #27.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/31)
<!-- Reviewable:end -->
