### PR TITLE
Apps: Add a button to convert into selfHosted

### DIFF
--- a/src/manage/extra-services/apps/app-request-ctrl.js
+++ b/src/manage/extra-services/apps/app-request-ctrl.js
@@ -23,6 +23,15 @@ export default /*@ngInject*/ function (
   ctrl.appType = (platform === "iOS") ? "iOS" : "Android";
 
 
+  ctrl.convertIntoSelfHosted = () => {
+    if (!ctrl.isAndroidApp) {
+      throw new Error("Converting into selfHosted is only for Android apps.");
+    }
+    ctrl.beforeSave();
+    ctrl.app.selfHosted = true;
+    return ctrl.save();
+  };
+
   ///////////////////////////////////////////////////////////////////////////////////////////////
   // Editable form
   ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/manage/extra-services/apps/view-app-request.html
+++ b/src/manage/extra-services/apps/view-app-request.html
@@ -21,21 +21,31 @@ If you think this is a mistake, please <a href="https://my.shoutca.st/submittick
 <div class="panel panel-default" ng-show="ctrl.app && ctrl.app._id">
 <div class="panel-body">
 
-<div class="flex-left-right">
-<h4 class="left flex-auto"><a class="back-link" href="/manage/apps"><fa name="chevron-left"></fa></a> Mobile Apps <small><i class="fa" ng-class="{'fa-apple': ctrl.isiOSApp, 'fa-android': ctrl.isAndroidApp}"></i> {{ctrl.app._id}} ({{ctrl.app.username}})</small></h4>
-<div class="right flex-auto no-transition visible-md visible-lg" ng-hide="editableForm.$visible">
-    <button ng-show="!editableForm.$visible" class="btn btn-default broad-button" ng-click="!ctrl.shouldBlockEditing(ctrl.app).blocked && editableForm.$show()" ng-class="{ disabled: ctrl.shouldBlockEditing(ctrl.app).blocked }" bs-tooltip data-title="{{ctrl.shouldBlockEditing(ctrl.app).blocked ? ctrl.shouldBlockEditing(ctrl.app).reason : ''}}" data-container="body"><i class="fa fa-edit"></i> Edit</button>
-</div>
-<div class="right flex-auto no-transition visible-md visible-lg" ng-show="editableForm.$visible">
-    <button type="submit" class="btn btn-primary broad-button" ng-disabled="editableForm.$waiting" form="info-form"><i class="fa fa-save"></i> Save</button>&nbsp;&nbsp;
-    <button type="button" class="btn btn-default broad-button" ng-disabled="editableForm.$waiting" ng-click="editableForm.$cancel()">Cancel</button>
-</div>
-</div>
-
-<br>
-
 <form editable-form name="editableForm" id="info-form" onbeforesave="ctrl.beforeSave()" onaftersave="ctrl.save()" onshow="ctrl.onEdit()" oncancel="ctrl.onCancel()">
     <fieldset ng-disabled="ctrl.disableForm">
+        <div class="flex-left-right">
+        <h4 class="left flex-auto"><a class="back-link" href="/manage/apps"><fa name="chevron-left"></fa></a> Mobile Apps <small><i class="fa" ng-class="{'fa-apple': ctrl.isiOSApp, 'fa-android': ctrl.isAndroidApp}"></i> {{ctrl.app._id}} ({{ctrl.app.username}})</small></h4>
+        <div class="right flex-auto no-transition visible-md visible-lg" ng-hide="editableForm.$visible">
+          <button type="button" class="btn btn-warning"
+            ng-show="ctrl.isAndroidApp && !ctrl.app.selfHosted"
+            ng-click="ctrl.convertIntoSelfHosted()"
+            bs-tooltip data-title="Convert the app into self-hosted (for more info, refer to docs.shoutca.st)" data-container="body">
+              Self-host</button>&nbsp;&nbsp;
+          <button type="button" class="btn btn-default broad-button"
+            ng-click="!ctrl.shouldBlockEditing(ctrl.app).blocked && editableForm.$show()"
+            ng-class="{ disabled: ctrl.shouldBlockEditing(ctrl.app).blocked }"
+            bs-tooltip data-title="{{ctrl.shouldBlockEditing(ctrl.app).blocked ? ctrl.shouldBlockEditing(ctrl.app).reason : ''}}" data-container="body">
+              <i class="fa fa-edit"></i> Edit</button>
+        </div>
+        <div class="right flex-auto no-transition visible-md visible-lg" ng-show="editableForm.$visible">
+          <button type="submit" class="btn btn-primary broad-button">
+            <i class="fa fa-save"></i> Save</button>&nbsp;&nbsp;
+          <button type="button" class="btn btn-default broad-button" ng-click="editableForm.$cancel()">
+            Cancel</button>
+        </div>
+        </div>
+        <br>
+
         <section>
             <dl class="dl-horizontal dl-taller">
                 <dt>Name</dt>


### PR DESCRIPTION
Easier to notice for clients, easier for them to convert their apps
into a selfHosted request, fewer clicks as well. Also not subject to
the edit restrictions, and allows having both the restrictions and
giving the user the right to edit their app request to turn it into a
selfHosted request.

(never mind the branch name, I ended up going for this approach rather than what I planned initially)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/42)
<!-- Reviewable:end -->
