### PR TITLE
Apps: Force self-hosted mode for Android apps

### DIFF
--- a/src/manage/extra-services/apps/request-app-ctrl.js
+++ b/src/manage/extra-services/apps/request-app-ctrl.js
@@ -395,14 +395,15 @@ export default /*@ngInject*/ function (
       hideExpression: "!model.platforms.android",
       defaultValue: true,
       templateOptions: {
+        required: true,
         label: "Host the Android app myself",
       },
     },
     {
       hideExpression: "!model.platforms.android",
       template: `
-<p class="help-block">You can choose to have your Android app submitted to our Google Play developer account (shared with other apps), or use your own which gives you better flexibility and reliability as your app is then independent.</p>
-<p class="help-block text-danger"><b>WARNING: If you don't host the app yourself, you may have to wait for a very long time (a few months) while we are working to resolve this issue with Google.</b></p>
+<p class="help-block">You <s>can choose to have your Android app submitted to our Google Play developer account (shared with other apps) or</s> use your own which gives you better flexibility and reliability as your app is then independent. Self-hosting apps is quick and easy.</s></p>
+<p class="help-block"><b class="text-danger">Because of ongoing and recurrent issues with Google, and to avoid very long waiting times (months), all Android apps MUST now be self-hosted.</b></p>
 <p class="help-block">For more information, please refer to <a href="https://docs.shoutca.st/v1.0/docs/apps#self-host-your-android-apps">the documentation</a>.</p>
 `,
     },

--- a/src/manage/extra-services/apps/view-app-request.html
+++ b/src/manage/extra-services/apps/view-app-request.html
@@ -84,7 +84,7 @@ If you think this is a mistake, please <a href="https://my.shoutca.st/submittick
                 <dd><span ng-show="ctrl.app.lastUpdated" data-placement="right" data-title="{{ctrl.app.lastUpdated| date:'yyyy-MM-dd HH:mm:ss Z'}}">{{ctrl.app.lastUpdated|date:'dd/MM/yyyy HH:mm Z'}}</span><span ng-show="!ctrl.app.lastUpdated">-</span></dd>
                 <div ng-show="ctrl.isAndroidApp">
                     <dt bs-tooltip data-title="Self-hosted (don't submit to Google Play)">Self-hosted</dt>
-                    <dd><span editable-checkbox="ctrl.app.selfHosted">{{ (ctrl.app.selfHosted) ? 'Yes' : 'No' }}</span></dd>
+                    <dd><span>{{ (ctrl.app.selfHosted) ? 'Yes' : 'No' }}</span></dd>
                 </div>
             </dl>
         </section>


### PR DESCRIPTION
Because a lot of users won't read and bother self-hosting unless they
are forced to, this commit does just that: force all new app requests
to self-hosted mode, and also prevent app requests from being edited to
non self-hosted mode.

This will likely be reverted if/when the issues with Google are resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/44)
<!-- Reviewable:end -->
