### PR TITLE
webpack: Fix tests

### DIFF
--- a/webpack.make.js
+++ b/webpack.make.js
@@ -78,6 +78,11 @@ module.exports = function makeWebpackConfig(options) {
         loader: "ng-annotate!babel-loader",
       },
       {
+        test: /\.js$/,
+        include: path.join(__dirname, "node_modules", "angular-route-segment"),
+        loader: "babel-loader",
+      },
+      {
         test: /\.css$/,
         loader: TEST ? "null" : "style-loader!css-loader",
       },


### PR DESCRIPTION
Since we use various ES6 features in the forked angular-route-segment,
we need babel as PhantomJS is incapable of handling any ES6 syntax.

This fixes tests and thus, deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/45)
<!-- Reviewable:end -->
