### PR TITLE
Cast: Cache the config better

### DIFF
--- a/src/manage/cast/config-service.js
+++ b/src/manage/cast/config-service.js
@@ -2,7 +2,8 @@ export default class ConfigService {
   /*@ngInject*/
   constructor($http, ENV, promiseCache, $rootScope, $q) {
     this.invalidateCache = function () {
-      promiseCache.remove("castConfig");
+      const username = $rootScope.service.username;
+      promiseCache.remove("castConfig_" + username);
     };
 
     this.getConfig = function () {
@@ -19,7 +20,7 @@ export default class ConfigService {
               return response.data;
             });
         },
-        key: "castConfig",
+        key: "castConfig_" + username,
         ttl: -1,
       });
     };
@@ -73,8 +74,6 @@ export default class ConfigService {
         .then(response => response.data);
     };
 
-
-    $rootScope.$on("selected-service-changed", this.invalidateCache);
     $rootScope.$on("invalidate-cast-config-cache", this.invalidateCache);
   }
 }


### PR DESCRIPTION
This makes ConfigService use different cache keys for different services
so we don't have to invalidate the whole cache every time the user
selects a different service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/control/60)
<!-- Reviewable:end -->
